### PR TITLE
ボタン系UIのレイアウトを変更

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -26,3 +26,73 @@ body .container .well.mod_template {
 	width: 120px;
 	margin: 4px 0 0 0;
 }
+
+.l_send {
+	position: fixed;
+	left: 0;
+	bottom: 0;
+	width: 100%;
+	padding: 20px 20px;
+}
+
+.l_send:after {
+	position: absolute;
+	content: "";
+	display: block;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background: #000000;
+	opacity: 0.2;
+	z-index: 0;
+}
+
+.l_send .input-group-btn {
+	display: table-cell;
+	position: relative;
+	padding: 0 20px;
+	z-index: 2;
+}
+
+.l_send .input-group-btn li {
+	display: table-cell;
+}
+
+@media (max-width: 768px) {
+	.l_send {
+		position: fixed;
+		left: 0;
+		bottom: 0;
+		width: 100%;
+		padding: 0;
+	}
+
+	.l_send .container {
+		padding: 0;
+	}
+
+	.l_send .input-group-btn {
+		margin: 0;
+		padding: 0;
+	}
+
+	.l_send .input-group-btn {
+		position: relative;
+		display: table;
+		table-layout: fixed;
+		width: 100%;
+		z-index: 2;
+	}
+
+	.l_send .input-group-btn li {
+		display: table-cell;
+	}
+
+	.l_send .input-group-btn input[type="submit"] {
+		margin: 0;
+		padding: 14px;
+		display: block;
+		width: 100%;
+	}
+}

--- a/app/views/nippos/new.html.slim
+++ b/app/views/nippos/new.html.slim
@@ -1,18 +1,21 @@
 = form_for @nippo, class: 'form-horizontal' do |f|
   .well
     fieldset
-      .form-group.label-floating
-        .input-group
-          label.control-label for="nippo_reported_for" 日付
-          = f.text_field(:reported_for, class: 'form-control', tabindex: -1)
-          p.help-block 指定した日付の日報として送信されます（件名にも挿入されます）
-          span.input-group-btn
-            = f.submit 'プレビュー', name: 'preview', class: 'btn btn-raised', tabindex: -1
-            = f.submit '日報送信', class: 'btn btn-info btn-raised', tabindex: 2
+      .form-group
+        label.control-label for="nippo_reported_for" 日付
+        = f.text_field(:reported_for, class: 'form-control', tabindex: -1)
+        p.help-block 指定した日付の日報として送信されます（件名にも挿入されます）
       .form-group.label-floating
         label.control-label for="nippo_body" 本文
         = f.text_area(:body, rows: 40, class: 'form-control', tabindex: 1)
-
+      .form-group.l_send
+        .container
+          ul.input-group-btn
+            li
+              = f.submit 'プレビュー', name: 'preview', class: 'btn btn-raised', tabindex: -1
+            li
+              = f.submit '日報送信', class: 'btn btn-info btn-raised', tabindex: 2
+              
 - if current_user.needing_tutorial?
   .modal#tutorial
     .modal-dialog

--- a/app/views/nippos/preview.html.slim
+++ b/app/views/nippos/preview.html.slim
@@ -2,13 +2,18 @@ p
   span.label.label-info プレビュー
 
 .row
-  .col-sm-3.col-sm-push-9.text-right
+  .col-sm-3.col-sm-push-9
     = form_for @nippo do |f|
       = f.hidden_field :reported_for
       = f.text_area :body, class: 'hidden'
-      = f.submit '戻る', name: 'back', class: 'btn btn-raised', tabindex: 2
-      = f.submit '日報送信', class: 'btn btn-info btn-raised', tabindex: 1
+      .form-group.l_send
+        .container
+          ul.input-group-btn
+            li
+              = f.submit '戻る', name: 'back', class: 'btn btn-raised', tabindex: 2
+            li
+              = f.submit '日報送信', class: 'btn btn-info btn-raised', tabindex: 1
   .col-sm-9.col-sm-pull-3
     h3 = @nippo.dated_subject
 
-.well = auto_link(@nippo.body).gsub(/(\r\n|\r|\n)/, '<br>').html_safe
+.well= auto_link(@nippo.body).gsub(/(\r\n|\r|\n)/, '<br>').html_safe

--- a/app/views/templates/show.html.slim
+++ b/app/views/templates/show.html.slim
@@ -30,8 +30,10 @@
       .form-group.label-floating
         label.control-label for="template_body" 本文
         = f.text_area(:body, rows: 30, class: 'form-control')
-      .form-group
-        = f.submit 'テンプレート保存', class: 'btn btn-raised btn-info'
+      .form-group.l_send
+        .container
+          span.input-group-btn
+            = f.submit 'テンプレート保存', class: 'btn btn-raised btn-info'
 
 - if current_user.needing_tutorial?
   .modal#tutorial


### PR DESCRIPTION
懲りずにボタン周りを修正してみましたがいかがでしょう。

PC画面サイズの際はウインドウサイズにかかわらず画面下固定で左下にボタン表示
![2016-06-15 21 11 29](https://cloud.githubusercontent.com/assets/949429/16079333/fc817acc-333d-11e6-83ce-f3e9a5ffcd54.png)

タブレットサイズ以下の場合は画面下固定で下記のようなレイアウトに
![2016-06-15 21 11 44](https://cloud.githubusercontent.com/assets/949429/16079366/27f68e2c-333e-11e6-9e34-71fc0e3a2060.png)
